### PR TITLE
Clearer explanation of scheduling on course web page

### DIFF
--- a/ds-rpackaging/description.md
+++ b/ds-rpackaging/description.md
@@ -1,5 +1,7 @@
-This workshop will help you make your research reproducible, by taking your script and turning it into a shareable R package.
+This workshop will help you make your research reproducible, by taking your R script and turning it into a shareable package.
 
 R packages are no more and no less than a standard way of structuring your work. The standardization makes packages easily installable and shareable, and allows others to reuse your code in a painless way, making your research more reproducible.
 
-But by turning your script into a package you achieve more than reusability: in doing so, you become a better programmer. In the structure of a package, best software development practices are implemented. You will learn to write tests and documentation, and help your users get started with a vignette. At the end of this workshop, we aim to have made your code more robust, and your experience more enjoyable.
+But by turning your script into a package you achieve more than reusability: in doing so, you become a better programmer. In the structure of a package, best software development practices are implemented. You will learn to write tests and documentation, and help your users get started with a vignette. At the end of this workshop, we aim to have made your code more robust, and your programming experience more enjoyable.
+
+**Note:** This workshop is scheduled as four weekly sessions, giving you time in between meetings to apply the things you learn to your own code. 

--- a/ds-rpackaging/title.md
+++ b/ds-rpackaging/title.md
@@ -1,1 +1,1 @@
-Reproducible Research with R Packages (weekly)
+Reproducible Research with R Packages

--- a/ds-rpackaging/title.md
+++ b/ds-rpackaging/title.md
@@ -1,1 +1,1 @@
-Reproducible Research with R Packages
+Reproducible Research with R Packages (weekly)


### PR DESCRIPTION
When creating the ds-rpackaging page for the Sept course, I noticed it was not very clear on the main webpage that this course would have an alternative schedule (namely: once a week, for four weeks).
This PR updates the metadata to make this more evident.