### PR TITLE
Fix the CR schedule: program starts at 9:15

### DIFF
--- a/ds-cr/schedule.md
+++ b/ds-cr/schedule.md
@@ -30,7 +30,7 @@
     <h3>Day 3</h3>
     <table class="table table-striped">
       <tr> <td>09:00</td> <td>Welcome and icebreaker </td> </tr>
-      <tr> <td>09:30</td>  <td>Writing modular code </td> </tr>
+      <tr> <td>09:15</td>  <td>Writing modular code </td> </tr>
       <tr> <td>10:15</td>  <td>Coffee break</td> </tr>
       <tr> <td>10:30</td>  <td>Writing modular code </td> </tr>
       <tr> <td>11:00</td>  <td>Documentation</td> </tr>
@@ -44,7 +44,7 @@
     <h3>Day 4</h3>
     <table class="table table-striped">
       <tr> <td>09:00</td> <td>Welcome and icebreaker </td> </tr>
-      <tr> <td>09:30</td>  <td>Introduction to testing </td> </tr>
+      <tr> <td>09:15</td>  <td>Introduction to testing </td> </tr>
       <tr> <td>10:15</td>  <td>Coffee break</td> </tr>
       <tr> <td>10:30</td>  <td>Introduction to Continuous Integration</td> </tr>
       <tr> <td>11:30</td>  <td>Coffee break </td> </tr>


### PR DESCRIPTION
I noticed when running the course that there was a small mistake in the online schedule. The welcome and icebreaker should not take 30 minutes but 15 (as on the first few days). This PR fixes that.