### PR TITLE
Update Geospatial Python workshop schedule

### DIFF
--- a/ds-geospatial-python/schedule.md
+++ b/ds-geospatial-python/schedule.md
@@ -2,14 +2,14 @@
   <div class="col-md-6">
     <h3>Day 1</h3>
     <table class="table table-striped">
-      <tr> <td>09:00</td> <td>Welcome and icebreaker </td> </tr>
-      <tr> <td>09:15</td>  <td>Introduction to raster, vector, and CRS </td> </tr>
-      <tr> <td>09:45</td>  <td>Access satellite imagery using Python</td> </tr>
-      <tr> <td>10:30</td>  <td>Coffee break</td> </tr>
-      <tr> <td>10:45</td>  <td>Read and visualize raster data</td> </tr>
+      <tr> <td>09:00</td> <td>Welcome and icebreaker, setup check </td> </tr>
+      <tr> <td>09:30</td>  <td>Introduction to raster, vector, and CRS </td> </tr>
+      <tr> <td>10:00</td>  <td>Access satellite imagery using Python</td> </tr>
+      <tr> <td>10:15</td>  <td>Coffee break</td> </tr>
+      <tr> <td>10:30</td>  <td>Access satellite imagery using Python</td> </tr>
       <tr> <td>11:30</td>  <td>Coffee break</td> </tr>
       <tr> <td>11:45</td>  <td>Read and visualize raster data</td> </tr>
-      <tr> <td>12:30</td>  <td>Wrap-up</td> </tr>
+      <tr> <td>12:45</td>  <td>Wrap-up</td> </tr>
       <tr> <td>13:00</td>  <td>END</td> </tr>
     </table>
   </div>
@@ -18,12 +18,11 @@
     <table class="table table-striped">
       <tr> <td>09:00</td>  <td>Welcome and icebreaker</td> </tr>
       <tr> <td>09:15</td>  <td>Vector data in Python</td> </tr>
-      <tr> <td>09:45</td>  <td>Crop raster data with rioxarray and geopandas</td> </tr>
-      <tr> <td>10:30</td>  <td>Coffee break</td> </tr>
-      <tr> <td>10:45</td>  <td>Crop raster data with rioxarray and geopandas</td> </tr>
+      <tr> <td>10:15</td>  <td>Coffee break</td> </tr>
+      <tr> <td>10:30</td>  <td>Crop raster data with rioxarray and geopandas</td> </tr>
       <tr> <td>11:30</td>  <td>Coffee break</td> </tr>
       <tr> <td>11:45</td>  <td>Raster Calculations in Python</td> </tr>
-      <tr> <td>12:30</td>  <td>Wrap-up</td> </tr>
+      <tr> <td>12:45</td>  <td>Wrap-up</td> </tr>
       <tr> <td>13:00</td>  <td>END</td> </tr>
     </table>
   </div>
@@ -34,9 +33,9 @@
       <tr> <td>09:15</td>  <td>Calculating Zonal Statistics on Rasters</td> </tr>
       <tr> <td>10:15</td>  <td>Coffee break</td> </tr>
       <tr> <td>10:30</td>  <td>Parallel raster computations using Dask</td> </tr>
-      <tr> <td>11:15</td>  <td>Coffee break</td> </tr>
-      <tr> <td>11:30</td>  <td>Parallel raster computations using Dask</td> </tr>
-      <tr> <td>12:30</td>  <td>Wrap-up</td> </tr>
+      <tr> <td>11:30</td>  <td>Coffee break</td> </tr>
+      <tr> <td>11:45</td>  <td>Parallel raster computations using Dask</td> </tr>
+      <tr> <td>12:45</td>  <td>Wrap-up</td> </tr>
       <tr> <td>13:00</td>  <td>END</td> </tr>
     </table>
   </div>


### PR DESCRIPTION
* Add more time at the beginning, leaving space for checking the setup.
* Leave always >=1 h teaching time in between coffee breaks.
* Leave wrap up for last 15 min (instead of 30 min)