### PR TITLE
update setup instructions for R packaging

### DIFF
--- a/ds-rpackaging/schedule-afternoon.md
+++ b/ds-rpackaging/schedule-afternoon.md
@@ -1,4 +1,4 @@
-This workshop is scheduled on four separate days. This allows you to work on
+This workshop is scheduled on four separate days over four weeks. This allows you to work on
 your package in between the sessions, implementing the lessons you learned
 during our meetings together. Please schedule dedicated work time in your
 calendar, so you can take full advantage of the workshop.

--- a/ds-rpackaging/schedule-afternoon.md
+++ b/ds-rpackaging/schedule-afternoon.md
@@ -1,0 +1,61 @@
+This workshop is scheduled on four separate days. This allows you to work on
+your package in between the sessions, implementing the lessons you learned
+during our meetings together. Please schedule dedicated work time in your
+calendar, so you can take full advantage of the workshop.
+
+<div class="row">
+  <div class="col-md-6">
+    <h3>Week 1</h3>
+    <table class="table table-striped">
+      <tr> <td>13:00</td> <td>Welcome and icebreaker </td> </tr>
+      <tr> <td>13:15</td> <td>Introduction, Accessing packages, Getting started</td> </tr>
+      <tr> <td>14:15</td> <td>Coffee break</td> </tr>
+      <tr> <td>14:30</td> <td>Writing our own functions, Licenses</td> </tr>
+      <tr> <td>15:30</td> <td>Coffee break</td> </tr>
+      <tr> <td>15:45</td> <td>Data</td> </tr>
+      <tr> <td>16:45</td> <td>Wrap-up</td> </tr>
+      <tr> <td>17:00</td> <td>END</td> </tr>
+    </table>
+  </div>
+  <div class="col-md-6">
+    <h3>Week 2</h3>
+    <table class="table table-striped">
+      <tr> <td>13:00</td> <td>Welcome and icebreaker</td> </tr>
+      <tr> <td>13:15</td> <td>Recap homework & Lessons learned</td> </tr>
+      <tr> <td>14:15</td> <td>Coffee break</td> </tr>
+      <tr> <td>14:30</td> <td>Testing</td> </tr>
+      <tr> <td>15:30</td> <td>Coffee break</td> </tr>
+      <tr> <td>15:45</td> <td>Testing, test coverage</td> </tr>
+      <tr> <td>16:45</td> <td>Wrap-up</td> </tr>
+      <tr> <td>17:00</td> <td>END</td> </tr>
+    </table>
+  </div>
+  <div class="col-md-6">
+    <h3>Week 3</h3>
+    <table class="table table-striped">
+      <tr> <td>13:00</td> <td>Welcome and icebreaker</td> </tr>
+      <tr> <td>13:15</td> <td>Recap homework & Lessons learned</td> </tr>
+      <tr> <td>14:15</td> <td>Coffee break</td> </tr>
+      <tr> <td>14:30</td> <td>Dependencies, Documenting your package</td> </tr>
+      <tr> <td>15:30</td> <td>Coffee break</td> </tr>
+      <tr> <td>15:45</td> <td>Documenting your package, Vignettes</td> </tr>
+      <tr> <td>16:45</td> <td>Wrap-up</td> </tr>
+      <tr> <td>17:00</td> <td>END</td> </tr>
+    </table>
+  </div>
+  <div class="col-md-6">
+    <h3>Week 4</h3>
+    <table class="table table-striped">
+      <tr> <td>13:00</td> <td>Welcome and icebreaker</td> </tr>
+      <tr> <td>13:15</td> <td>Recap homework & Lessons learned</td> </tr>
+      <tr> <td>14:15</td> <td>Coffee break</td> </tr>
+      <tr> <td>14:30</td> <td>Vignettes</td> </tr>
+      <tr> <td>15:30</td> <td>Coffee break</td> </tr>
+      <tr> <td>15:45</td> <td>Sharing our packages</td> </tr>
+      <tr> <td>16:45</td> <td>Wrap-up</td> </tr>
+      <tr> <td>17:00</td> <td>END</td> </tr>
+    </table>
+  </div>
+</div>
+
+<p><b>All times in the schedule are in the CET timezone (Amsterdam time).</b></p>

--- a/ds-rpackaging/schedule-afternoon.md
+++ b/ds-rpackaging/schedule-afternoon.md
@@ -1,6 +1,7 @@
-This workshop is scheduled on four separate days over four weeks. This allows you to work on
-your package in between the sessions, implementing the lessons you learned
-during our meetings together. Please schedule dedicated work time in your
+This workshop is scheduled on four separate days over four weeks.
+This allows you to work on your package in between the sessions,
+implementing the lessons you learned during the teaching moments.
+Please schedule dedicated time for homework in your
 calendar, so you can take full advantage of the workshop.
 
 <div class="row">
@@ -58,4 +59,4 @@ calendar, so you can take full advantage of the workshop.
   </div>
 </div>
 
-<p><b>All times in the schedule are in the CET timezone (Amsterdam time).</b></p>
+<p><b>All times in the schedule are in the CE(S)T timezone (Amsterdam time).</b></p>

--- a/ds-rpackaging/schedule.md
+++ b/ds-rpackaging/schedule.md
@@ -8,11 +8,11 @@ calendar, so you can take full advantage of the workshop.
     <h3>Week 1</h3>
     <table class="table table-striped">
       <tr> <td>13:00</td> <td>Welcome and icebreaker </td> </tr>
-      <tr> <td>13:15</td> <td>Introduction, Accessing packages</td> </tr>
+      <tr> <td>13:15</td> <td>Introduction, Accessing packages, Getting started</td> </tr>
       <tr> <td>14:15</td> <td>Coffee break</td> </tr>
-      <tr> <td>14:30</td> <td>Getting started, Writing our own functions</td> </tr>
+      <tr> <td>14:30</td> <td>Writing our own functions, Licenses</td> </tr>
       <tr> <td>15:30</td> <td>Coffee break</td> </tr>
-      <tr> <td>15:45</td> <td>Writing our own functions, Licenses</td> </tr>
+      <tr> <td>15:45</td> <td>Data</td> </tr>
       <tr> <td>16:45</td> <td>Wrap-up</td> </tr>
       <tr> <td>17:00</td> <td>END</td> </tr>
     </table>
@@ -36,9 +36,9 @@ calendar, so you can take full advantage of the workshop.
       <tr> <td>13:00</td> <td>Welcome and icebreaker</td> </tr>
       <tr> <td>13:15</td> <td>Recap homework & Lessons learned</td> </tr>
       <tr> <td>14:15</td> <td>Coffee break</td> </tr>
-      <tr> <td>14:30</td> <td>Dependencies, Data</td> </tr>
+      <tr> <td>14:30</td> <td>Dependencies</td> </tr>
       <tr> <td>15:30</td> <td>Coffee break</td> </tr>
-      <tr> <td>15:45</td> <td>Documenting your package</td> </tr>
+      <tr> <td>15:45</td> <td>Documenting your package, Vignettes</td> </tr>
       <tr> <td>16:45</td> <td>Wrap-up</td> </tr>
       <tr> <td>17:00</td> <td>END</td> </tr>
     </table>

--- a/ds-rpackaging/schedule.md
+++ b/ds-rpackaging/schedule.md
@@ -1,6 +1,7 @@
-This workshop is scheduled on four separate days. This allows you to work on
-your package in between the sessions, implementing the lessons you learned
-during our meetings together. Please schedule dedicated work time in your
+This workshop is scheduled on four separate days over four weeks.
+This allows you to work on your package in between the sessions,
+implementing the lessons you learned during the teaching moments.
+Please schedule dedicated time for homework in your
 calendar, so you can take full advantage of the workshop.
 
 <div class="row">
@@ -58,4 +59,4 @@ calendar, so you can take full advantage of the workshop.
   </div>
 </div>
 
-<p><b>All times in the schedule are in the CET timezone (Amsterdam time).</b></p>
+<p><b>All times in the schedule are in the CE(S)T timezone (Amsterdam time).</b></p>

--- a/ds-rpackaging/schedule.md
+++ b/ds-rpackaging/schedule.md
@@ -7,53 +7,53 @@ calendar, so you can take full advantage of the workshop.
   <div class="col-md-6">
     <h3>Week 1</h3>
     <table class="table table-striped">
-      <tr> <td>13:00</td> <td>Welcome and icebreaker </td> </tr>
-      <tr> <td>13:15</td> <td>Introduction, Accessing packages, Getting started</td> </tr>
-      <tr> <td>14:15</td> <td>Coffee break</td> </tr>
-      <tr> <td>14:30</td> <td>Writing our own functions, Licenses</td> </tr>
-      <tr> <td>15:30</td> <td>Coffee break</td> </tr>
-      <tr> <td>15:45</td> <td>Data</td> </tr>
-      <tr> <td>16:45</td> <td>Wrap-up</td> </tr>
-      <tr> <td>17:00</td> <td>END</td> </tr>
+      <tr> <td>9:00</td> <td>Welcome and icebreaker </td> </tr>
+      <tr> <td>9:15</td> <td>Introduction, Accessing packages, Getting started</td> </tr>
+      <tr> <td>10:15</td> <td>Coffee break</td> </tr>
+      <tr> <td>10:30</td> <td>Writing our own functions, Licenses</td> </tr>
+      <tr> <td>11:30</td> <td>Coffee break</td> </tr>
+      <tr> <td>11:45</td> <td>Data</td> </tr>
+      <tr> <td>12:45</td> <td>Wrap-up</td> </tr>
+      <tr> <td>13:00</td> <td>END</td> </tr>
     </table>
   </div>
   <div class="col-md-6">
     <h3>Week 2</h3>
     <table class="table table-striped">
-      <tr> <td>13:00</td> <td>Welcome and icebreaker</td> </tr>
-      <tr> <td>13:15</td> <td>Recap homework & Lessons learned</td> </tr>
-      <tr> <td>14:15</td> <td>Coffee break</td> </tr>
-      <tr> <td>14:30</td> <td>Testing</td> </tr>
-      <tr> <td>15:30</td> <td>Coffee break</td> </tr>
-      <tr> <td>15:45</td> <td>Testing, test coverage</td> </tr>
-      <tr> <td>16:45</td> <td>Wrap-up</td> </tr>
-      <tr> <td>17:00</td> <td>END</td> </tr>
+      <tr> <td>9:00</td> <td>Welcome and icebreaker</td> </tr>
+      <tr> <td>9:15</td> <td>Recap homework & Lessons learned</td> </tr>
+      <tr> <td>10:15</td> <td>Coffee break</td> </tr>
+      <tr> <td>10:30</td> <td>Testing</td> </tr>
+      <tr> <td>11:30</td> <td>Coffee break</td> </tr>
+      <tr> <td>11:45</td> <td>Testing, test coverage</td> </tr>
+      <tr> <td>12:45</td> <td>Wrap-up</td> </tr>
+      <tr> <td>13:00</td> <td>END</td> </tr>
     </table>
   </div>
   <div class="col-md-6">
     <h3>Week 3</h3>
     <table class="table table-striped">
-      <tr> <td>13:00</td> <td>Welcome and icebreaker</td> </tr>
-      <tr> <td>13:15</td> <td>Recap homework & Lessons learned</td> </tr>
-      <tr> <td>14:15</td> <td>Coffee break</td> </tr>
-      <tr> <td>14:30</td> <td>Dependencies</td> </tr>
-      <tr> <td>15:30</td> <td>Coffee break</td> </tr>
-      <tr> <td>15:45</td> <td>Documenting your package, Vignettes</td> </tr>
-      <tr> <td>16:45</td> <td>Wrap-up</td> </tr>
-      <tr> <td>17:00</td> <td>END</td> </tr>
+      <tr> <td>9:00</td> <td>Welcome and icebreaker</td> </tr>
+      <tr> <td>9:15</td> <td>Recap homework & Lessons learned</td> </tr>
+      <tr> <td>10:15</td> <td>Coffee break</td> </tr>
+      <tr> <td>10:30</td> <td>Dependencies, Documenting your package</td> </tr>
+      <tr> <td>11:30</td> <td>Coffee break</td> </tr>
+      <tr> <td>11:45</td> <td>Documenting your package, Vignettes</td> </tr>
+      <tr> <td>12:45</td> <td>Wrap-up</td> </tr>
+      <tr> <td>13:00</td> <td>END</td> </tr>
     </table>
   </div>
   <div class="col-md-6">
     <h3>Week 4</h3>
     <table class="table table-striped">
-      <tr> <td>13:00</td> <td>Welcome and icebreaker</td> </tr>
-      <tr> <td>13:15</td> <td>Recap homework & Lessons learned</td> </tr>
-      <tr> <td>14:15</td> <td>Coffee break</td> </tr>
-      <tr> <td>14:30</td> <td>Vignettes</td> </tr>
-      <tr> <td>15:30</td> <td>Coffee break</td> </tr>
-      <tr> <td>15:45</td> <td>Sharing our packages</td> </tr>
-      <tr> <td>16:45</td> <td>Wrap-up</td> </tr>
-      <tr> <td>17:00</td> <td>END</td> </tr>
+      <tr> <td>9:00</td> <td>Welcome and icebreaker</td> </tr>
+      <tr> <td>9:15</td> <td>Recap homework & Lessons learned</td> </tr>
+      <tr> <td>10:15</td> <td>Coffee break</td> </tr>
+      <tr> <td>10:30</td> <td>Vignettes</td> </tr>
+      <tr> <td>11:30</td> <td>Coffee break</td> </tr>
+      <tr> <td>11:45</td> <td>Sharing our packages</td> </tr>
+      <tr> <td>12:45</td> <td>Wrap-up</td> </tr>
+      <tr> <td>13:00</td> <td>END</td> </tr>
     </table>
   </div>
 </div>

--- a/ds-rpackaging/setup.md
+++ b/ds-rpackaging/setup.md
@@ -30,6 +30,8 @@ $ library(roxygen2)
 ~~~
 {: .language-r}
 
+Please contact us in advance if you are experiencing problems.
+
 ### GitHub account
 
 You will need an account on GitHub. [Create one here](https://github.com/signup).
@@ -41,5 +43,3 @@ shareable R package. You are encouraged to bring your own project, though we
 will have a toy project to use if you are unable to. Packages are based around
 functions, so it is important that you know how to write functions, and that at
 least a single function is present in your script.
-
-Please contact us in advance if you are experiencing problems.

--- a/ds-rpackaging/setup.md
+++ b/ds-rpackaging/setup.md
@@ -1,9 +1,12 @@
-This lesson assumes you have current versions of the following installed on your computer:
+### R software and IDE
+
+For this workshop, you will need to install the following software:
 
 1. the [R software](https://cran.r-project.org/mirrors.html) itself, and
 2. [RStudio Desktop](https://www.rstudio.com/products/rstudio/download/#download).
+3. (Windows users only) the packaging toolkit [Rtools](https://cran.r-project.org/bin/windows/Rtools/).
 
-In addition, you will need an account on GitHub. [Create one here](https://github.com/signup).
+### R packages
 
 You will also need to install the following packages:
 
@@ -27,10 +30,16 @@ $ library(roxygen2)
 ~~~
 {: .language-r}
 
-Please contact us in advance if you are experiencing problems.
+### GitHub account
+
+You will need an account on GitHub. [Create one here](https://github.com/signup).
+
+### Preparation and prior knowledge
 
 During the workshop, we will take an R script, and transform it into a
 shareable R package. You are encouraged to bring your own project, though we
 will have a toy project to use if you are unable to. Packages are based around
 functions, so it is important that you know how to write functions, and that at
 least a single function is present in your script.
+
+Please contact us in advance if you are experiencing problems.


### PR DESCRIPTION
Updates for workshop 2023-09-20:

- The R packaging course requires windows users to have Rtools installed. This was not yet part of the setup instructions.
- This PR also slightly rewrites the instructions to make them more readable (i.e. it adds headers, so things will not be overlooked as easily).
- The schedule is duplicated into a morning (default) and afternoon schedule
- The 'data' episode is moved to day 1

Ready to be reviewed @liekelotte!