### PR TITLE
Add description for workshop with git part of the regular curriculum

### DIFF
--- a/ds-cr/description-no-option.md
+++ b/ds-cr/description-no-option.md
@@ -1,0 +1,9 @@
+The key objective of this workshop is to grow researchers' software skills necessary
+to apply good practices that enable open and reproducible research.
+The workshop focuses on building modular, reusable, maintainable, sustainable, reproducible,
+testable, and robust software. This will allow you to more easily organize, maintain and share your data. 
+The participants should be familiar with programming and regularly write code for their research, 
+but no extensive expertise or knowledge of specific tools are required.
+
+This workshop is inspired by and based on [CodeRefinery](https://coderefinery.org/lessons/)
+training materials.


### PR DESCRIPTION
This description should be used in combination with the new schedule-in-person.md which includes the git introduction in the regular workshop.