### PR TITLE
Remove example breaking the website build

### DIFF
--- a/ds-research-software-support/setup.md
+++ b/ds-research-software-support/setup.md
@@ -1,17 +1,1 @@
-<div style="background: red; color: black;">FIXME</div>
-
-Please delete the contents of this file and fill it with your own. You can add
-setup instructions to this file or add a link to lesson `setup.md`, see examples
-below. The setup should cover 3 major platforms: Windows, MacOS and Linux.
-
-## Expected contents
-
-A list of the requirements **or** only the link to the lesson `setup.md`. (Both
-are not supported!)
-
-## Examples
-
-- For most users we recommend that you use `conda` to install the requirements
-  for the workshop.
-
-- carpentries-incubator/deep-learning-intro/gh-pages/setup.md
+For this workshop you need a laptop and access to the internet.


### PR DESCRIPTION
The example metadata is breaking the workshop website build as there is both a description and a link. This is not supported.