### PR TITLE
Setup instructions ds-cr

### DIFF
--- a/ds-cr/setup.md
+++ b/ds-cr/setup.md
@@ -12,35 +12,11 @@ To participate in this workshop, you will need to prepare the following:
   
 Please refer to [this page](https://carpentries-incubator.github.io/collaborative-git-and-github-lesson/) for detailed instructions.
 
-- Install Miniconda. Please refer to [this page](https://coderefinery.github.io/installation/conda/) for instructions.
-- Create a Conda environment for the workshop. Please refer to [this page](https://coderefinery.github.io/installation/conda-environment/) for instructions.
+- Install Miniconda.
+- Create a Conda environment for the workshop. 
 
-#### Conda
-```
-conda --version
-```
-returning (something similar to):
-```
-conda 22.9.0
-```
+Please refer to [this page](https://esciencecenter-digital-skills.github.io/good-practices-lesson/#software-setup) for instructions.
 
-#### Conda environment for the workshop
-```
-conda activate coderefinery
-python -c "import sys; assert sys.version_info.major>=3"
-jupyter-lab --version
-pytest --version
-sphinx-build --version
-snakemake --version
-conda deactivate
-```
-returning (something similar to):
-```
-3.9.10
-pytest 7.0.1
-sphinx-build 4.4.0
-7.1.1
-```
 
 #### If something does not work:
 Follow the corresponding setup instructions. If you still need help, come to our dedicated setup session.

--- a/ds-cr/setup.md
+++ b/ds-cr/setup.md
@@ -4,35 +4,16 @@ Participants must work on a computer with a Mac, Linux, or Windows operating sys
 
 ### Software
 
-To participate in this workshop, you will need to prepare the following (if you haven't already):
-- Install Shell and Git. Please refer to [this page](https://coderefinery.github.io/installation/git-in-terminal/#installation) for installation instructions.
-- Create a GitHub account. Please refer to [this page](https://coderefinery.github.io/installation/github/) for instructions.
-- Set up an SSH connection to GitHub. Please refer to [this page](https://coderefinery.github.io/installation/ssh/) for instructions.
+To participate in this workshop, you will need to prepare the following:
+
+- Install Shell and Git.
+- Create a GitHub account.
+- Set up an SSH connection to GitHub. 
+  
+Please refer to [this page](https://carpentries-incubator.github.io/collaborative-git-and-github-lesson/) for detailed instructions.
+
 - Install Miniconda. Please refer to [this page](https://coderefinery.github.io/installation/conda/) for instructions.
 - Create a Conda environment for the workshop. Please refer to [this page](https://coderefinery.github.io/installation/conda-environment/) for instructions.
-
-### To confirm that everything works
-
-You should now be able to open [a terminal window](https://swcarpentry.github.io/shell-novice/#open-a-new-shell) and execute the following commands:
-
-#### Git
-```
-git --version
-```
-returning (something similar to):
-```
-git version 2.37.1 (Apple Git-137.1)
-```
-
-#### Github account & SSH connection 
-```
-ssh git@github.com
-```
-returning (something similar to):
-```
-Hi [username]! You've successfully authenticated, but GitHub does not provide shell access.
-Connection to github.com closed.
-```
 
 #### Conda
 ```

--- a/ds-cr/setup.md
+++ b/ds-cr/setup.md
@@ -12,6 +12,9 @@ To participate in this workshop, you will need to prepare the following:
   
 Please refer to [this page](https://carpentries-incubator.github.io/collaborative-git-and-github-lesson/) for detailed instructions.
 
+
+In addition, you will need to:
+
 - Install Miniconda.
 - Create a Conda environment for the workshop. 
 


### PR DESCRIPTION
Fixes #93 

It is now proposed to direct learners to a separate setup instructions for the corresponding lesson. 
This removes duplicated info and contains a simplified version of the setup to avoid confusion.
 
Related:
#https://github.com/carpentries-incubator/collaborative-git-and-github-lesson/issues/24
#https://github.com/esciencecenter-digital-skills/good-practices-lesson/issues/20